### PR TITLE
[zzawang] Step2 : B+ Tree

### DIFF
--- a/src/main/java/edu/berkeley/cs186/database/cli/CommandLineInterface.java
+++ b/src/main/java/edu/berkeley/cs186/database/cli/CommandLineInterface.java
@@ -21,7 +21,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 public class CommandLineInterface {
-    private static String mascot = ""\n" +
+    private static String mascot = "\n" +
             "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⡠⢄⠦⡰⢄⢄⡀⠀⠀⠀⢀⠠⡄⠴⠤⢤⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n" +
             "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡠⡪⡑⠜⠐⠑⠘⠐⠅⢎⠦⣀⢔⠕⡱⠘⠈⠊⠂⠢⡙⢔⢄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n" +
             "⠀⠀⠀⠀⠀⠀⠀⠀⠀⡰⡱⠜⠀⠀⠀⠀⠀⠀⠀⢈⢆⢕⢌⡂⠀⠀⠀⠀⠀⠀⠀⠑⡅⡣⠀⠀⠀⠀⠀⠀⠀⠀⠀\n" +


### PR DESCRIPTION
## ✅ 구현 내용
아래 클래스의 **TODO proj2** 구현
* [BPlusTree.java](https://github.com/berkeley-cs186/sp24-rookiedb/blob/master/src/main/java/edu/berkeley/cs186/database/index/BPlusTree.java)
* [InnerNode.java](https://github.com/berkeley-cs186/sp24-rookiedb/blob/master/src/main/java/edu/berkeley/cs186/database/index/InnerNode.java)
* [LeafNode.java](https://github.com/berkeley-cs186/sp24-rookiedb/blob/master/src/main/java/edu/berkeley/cs186/database/index/LeafNode.java)

<br><br>

## 🤔 고민 사항
### 1️⃣ 인덱스 계산 실패
### 문제
```java
private BPlusNode findChildByKey(DataBox key) {
    int n = keys.size();
        for (int i = 0; i < n + 1; i++) {
            // 조건에 맞는 BPlusNode 반환
            if ((i == 0 || key.compareTo(keys.get(i - 1)) >= 0) && (i == n || key.compareTo(keys.get(i)) < 0)) {
                return getChild(i);
            }
        }
    return null;
}
```
위의 코드로 key값을 이용하여 데이터를 삽입할 위치를 찾도록 직접 구현하였었다. InnerNode와 LeafNode의 테스트 코드를 모두 통과해서 문제가 없는 줄 알았으나, TestBPlusTree의 #testWhiteBoxTest() 에서 테스트 실패가 발생하였다. 


### 해결
InnerNode의 #numLessThanEqual()와 #numLessThan() 메소드를 사용하여 해결하였다.

<br><br>

### 2️⃣ `sync()`를 하지 않아 발생한 문제

put()과 remove() 메소드를 구현할 때 반드시 `sync()`를 호출해야 하는데, 이를 추가하지 않아 #testNoOverflowPutsFromDisk() 테스트가 실패하였다. <br>

`sync()`를 호출해야 하는 이유를 찾아보니, 데이터 구조에서 버퍼는 **데이터를 임시로 저장하는 메모리 영역**을 의미하는데, 버퍼에 있는 노드의 데이터가 실제 프로그램이 실행되는 메모리 영역에 있는 데이터와 다를 수 있기 때문에 이를 동기화, 즉 같게 해줘야 한다고 한다. 